### PR TITLE
Support trivy command and target

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,7 @@ jobs:
         id: test
         with:
           github_token: ${{ secrets.github_token }}
+          trivy_command: config
           reporter: github-check
           level: info
           working_directory: testdata/with_detections
@@ -60,6 +61,7 @@ jobs:
         id: test
         with:
           github_token: ${{ secrets.github_token }}
+          trivy_command: config
           reporter: github-check
           level: info
           working_directory: testdata/without_detections
@@ -98,6 +100,7 @@ jobs:
         id: test
         with:
           github_token: ${{ secrets.github_token }}
+          trivy_command: config
           reporter: github-pr-check
           level: info
           working_directory: testdata/with_detections
@@ -136,6 +139,7 @@ jobs:
         id: test
         with:
           github_token: ${{ secrets.github_token }}
+          trivy_command: config
           reporter: github-pr-review
           level: info
           working_directory: testdata/with_detections
@@ -179,6 +183,7 @@ jobs:
         id: test
         with:
           github_token: ${{ secrets.github_token }}
+          trivy_command: config
           reporter: github-check
           level: info
           working_directory: testdata/with_detections

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           trivy_command: config
+          trivy_target: .
           reporter: github-check
           level: info
           working_directory: testdata/with_detections
@@ -62,6 +63,7 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           trivy_command: config
+          trivy_target: .
           reporter: github-check
           level: info
           working_directory: testdata/without_detections
@@ -101,6 +103,7 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           trivy_command: config
+          trivy_target: .
           reporter: github-pr-check
           level: info
           working_directory: testdata/with_detections
@@ -140,6 +143,7 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           trivy_command: config
+          trivy_target: .
           reporter: github-pr-review
           level: info
           working_directory: testdata/with_detections
@@ -184,6 +188,7 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           trivy_command: config
+          trivy_target: .
           reporter: github-check
           level: info
           working_directory: testdata/with_detections

--- a/README.md
+++ b/README.md
@@ -35,7 +35,13 @@ the Pull Request Conversation:
 
 ### `trivy_command`
 
-**Required**. Must be in form of `github_token: ${{ secrets.github_token }}`.
+**Required**. Trivy command [`aws`, `config`, `filesystem`,  `image`, `kubernetes`, `rootfs`, `sbom`, `vm`].
+You can see this with `trivy --help`
+
+### `trivy_target`
+
+**Required**. Target to scan.
+It's depends on the command. Please check [Trivy Docs](https://aquasecurity.github.io/trivy/latest/docs/)
 
 ### `working_directory`
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ the Pull Request Conversation:
 
 **Required**. Must be in form of `github_token: ${{ secrets.github_token }}`.
 
+### `trivy_command`
+
+**Required**. Must be in form of `github_token: ${{ secrets.github_token }}`.
+
 ### `working_directory`
 
 Optional. Directory to run the action on, from the repo root.

--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,10 @@ inputs:
       Default is latest.
     default: 'latest'
     required: false
+  trivy_command:
+    description: |
+      Trivy command
+    required: true
   trivy_flags:
     description: |
       List of arguments to send to trivy
@@ -88,6 +92,7 @@ runs:
         INPUT_FAIL_ON_ERROR: ${{ inputs.fail_on_error }}
         INPUT_FLAGS: ${{ inputs.flags }}
         INPUT_TRIVY_VERSION: ${{ inputs.trivy_version }}
+        INPUT_TRIVY_COMMAND: ${{ inputs.trivy_command }}
         INPUT_TRIVY_FLAGS: ${{ inputs.trivy_flags }}
 
 branding:

--- a/action.yml
+++ b/action.yml
@@ -45,16 +45,20 @@ inputs:
     description: 'Additional reviewdog flags'
     default: ''
     required: false
+  trivy_command:
+    description: |
+      Trivy command [aws,config,filesystem,image,kubernetes,rootfs,sbom,vm]
+    required: true
+  trivy_target:
+    description: |
+      Trivy target to scan
+    required: true
   trivy_version:
     description: |
       The version of trivy to install.
       Default is latest.
     default: 'latest'
     required: false
-  trivy_command:
-    description: |
-      Trivy command
-    required: true
   trivy_flags:
     description: |
       List of arguments to send to trivy
@@ -93,6 +97,7 @@ runs:
         INPUT_FLAGS: ${{ inputs.flags }}
         INPUT_TRIVY_VERSION: ${{ inputs.trivy_version }}
         INPUT_TRIVY_COMMAND: ${{ inputs.trivy_command }}
+        INPUT_TRIVY_TARGET: ${{ inputs.trivy_target }}
         INPUT_TRIVY_FLAGS: ${{ inputs.trivy_flags }}
 
 branding:

--- a/script.sh
+++ b/script.sh
@@ -82,7 +82,7 @@ echo '::group:: Running trivy with reviewdog 🐶 ...'
   set +Eeuo pipefail
 
   # shellcheck disable=SC2086
-  "${TRIVY_PATH}/trivy" --format json ${INPUT_TRIVY_FLAGS:-} --exit-code 1 ${INPUT_TRIVY_COMMAND} . 2> /dev/null \
+  "${TRIVY_PATH}/trivy" --format json ${INPUT_TRIVY_FLAGS:-} --exit-code 1 ${INPUT_TRIVY_COMMAND} ${INPUT_TRIVY_TARGET} 2> /dev/null \
     | jq -r -f "${GITHUB_ACTION_PATH}/to-rdjson.jq" \
     |  "${REVIEWDOG_PATH}/reviewdog" -f=rdjson \
         -name="${INPUT_TOOL_NAME}" \

--- a/script.sh
+++ b/script.sh
@@ -82,7 +82,7 @@ echo '::group:: Running trivy with reviewdog 🐶 ...'
   set +Eeuo pipefail
 
   # shellcheck disable=SC2086
-  "${TRIVY_PATH}/trivy" --format json ${INPUT_TRIVY_FLAGS:-} --exit-code 1 config . 2> /dev/null \
+  "${TRIVY_PATH}/trivy" --format json ${INPUT_TRIVY_FLAGS:-} --exit-code 1 ${INPUT_TRIVY_COMMAND} . 2> /dev/null \
     | jq -r -f "${GITHUB_ACTION_PATH}/to-rdjson.jq" \
     |  "${REVIEWDOG_PATH}/reviewdog" -f=rdjson \
         -name="${INPUT_TOOL_NAME}" \


### PR DESCRIPTION
Trivy supports multiple scan types but tfsec only supports terraform scan. So I added two parameters.
- trivy_command
  - Tirvy command (for scanning terraform, we need to use `config`)
- trivy_target
  - Target to scan (with tfsec, it set to `.`)

Related conversation: https://github.com/reviewdog/action-tfsec/issues/112#issuecomment-1842148895