### PR TITLE
Add error message when trivy_command and trivy_target are not provided

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -5,6 +5,16 @@ if [[ "$RUNNER_DEBUG" = "1" ]]; then
   set -x
 fi
 
+if [[ -z "${INPUT_TRIVY_COMMAND}" ]]; then
+  echo "Error: Missing required input 'trivy_command'."
+  exit 1
+fi
+
+if [[ -z "${INPUT_TRIVY_TARGET}" ]]; then
+  echo "Error: Missing required input 'trivy_target'."
+  exit 1
+fi
+
 # Fail fast on errors, unset variables, and failures in piped commands
 set -Eeuo pipefail
 


### PR DESCRIPTION
To https://github.com/reviewdog/action-trivy/issues/17, add error messages

Changes:

- The error message will be printed when `trivy_command` and `trivy_target` are provided