### PR TITLE
Support for `aarch64` architecture (which is equivalent to `arm64`)

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -34,6 +34,7 @@ echo '::group::Preparing ...'
   unameArch="$(uname -m)"
   case "${unameArch}" in
     x86*)      arch=64bit;;
+    aarch64)   arch=ARM64;;
     arm64)     arch=ARM64;;
     *)         echo "Unsupported architecture: ${unameArch}. Only AMD64 and ARM64 are supported by the action" && exit 1
     esac


### PR DESCRIPTION
## Overview

This PR adds support for `aarch64` by updating the case handling to treat `aarch64` as equivalent to `arm64`.


## Details

In certain OS environments, such as [Amazon Linux 2023](https://aws.amazon.com/linux/amazon-linux-2023/), `uname -m` returns `aarch64` instead of `arm64`, even though both represent the same 64-bit ARM architecture.

For instance, when using this action on [self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners) configured with [AWS CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/action-runner-questions.html) and Amazon Linux 2023, an `Unsupported architecture` error occurs because the current script expects `uname -m` to return `arm64`.

I’ve already verified that this patch works as expected in the environment described above.