### PR TITLE
Support reviewdog command line argument changes (--fail-level)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ See [reviewdog documentation for exit codes](https://github.com/reviewdog/review
 
 ### `fail_level`
 
-Optional. The level of failures that will cause the action to fail [any,info,warning,error].
+Optional. If set to none, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level. Possible values: [none, any, info, warning, error] Default is none.
 
-The default is `error`.
+The default is `none`.
 
 See [reviewdog documentation for fail level](https://github.com/reviewdog/reviewdog/tree/master?tab=readme-ov-file#fail-level) for details.
 

--- a/README.md
+++ b/README.md
@@ -80,11 +80,21 @@ See [reviewdog documentation for filter mode](https://github.com/reviewdog/revie
 
 ### `fail_on_error`
 
+**Deprecated**. This option is no longer recommended for use and will be removed in future versions.
+
 Optional. Exit code for reviewdog when errors are found [`true`, `false`].
 
 The default is `false`.
 
 See [reviewdog documentation for exit codes](https://github.com/reviewdog/reviewdog/tree/master#exit-codes) for details.
+
+### `fail_level`
+
+Optional. The level of failures that will cause the action to fail [any,info,warning,error].
+
+The default is `error`.
+
+See [reviewdog documentation for fail level](https://github.com/reviewdog/reviewdog/tree/master?tab=readme-ov-file#fail-level) for details.
 
 ### `flags`
 
@@ -139,6 +149,7 @@ jobs:
           reporter: github-pr-review # Change reviewdog reporter
           filter_mode: nofilter # Check all files, not just the diff
           fail_on_error: true # Fail action if errors are found
+          fail_level: any # Fail action if any level of failures are found
           flags: -tee # Add debug flag to reviewdog
           trivy_flags: "" # Optional
 ```

--- a/action.yml
+++ b/action.yml
@@ -35,12 +35,20 @@ inputs:
       Default is added.
     default: 'added'
     required: false
+  fail_level:
+    description: |
+      The level of failures that will cause the action to fail [any,info,warning,error]
+      Default is error.
+    default: ''
+    required: false
   fail_on_error:
     description: |
+      **Deprecated**. This option is no longer recommended for use and will be removed in future versions.
       Exit code for reviewdog when errors are found [true,false]
       Default is `false`.
     default: 'false'
     required: false
+    deprecated: true
   flags:
     description: 'Additional reviewdog flags'
     default: ''
@@ -94,6 +102,7 @@ runs:
         INPUT_TOOL_NAME: ${{ inputs.tool_name }}
         INPUT_FILTER_MODE: ${{ inputs.filter_mode }}
         INPUT_FAIL_ON_ERROR: ${{ inputs.fail_on_error }}
+        INPUT_FAIL_LEVEL: ${{ inputs.fail_level }}
         INPUT_FLAGS: ${{ inputs.flags }}
         INPUT_TRIVY_VERSION: ${{ inputs.trivy_version }}
         INPUT_TRIVY_COMMAND: ${{ inputs.trivy_command }}

--- a/action.yml
+++ b/action.yml
@@ -37,9 +37,8 @@ inputs:
     required: false
   fail_level:
     description: |
-      The level of failures that will cause the action to fail [any,info,warning,error]
-      Default is error.
-    default: ''
+      If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level. Possible values: [none,any,info,warning,error] Default is `none`.
+    default: 'none'
     required: false
   fail_on_error:
     description: |

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ inputs:
       Default is `false`.
     default: 'false'
     required: false
-    deprecated: true
+    deprecationMessage: Deprecated, use `fail_level` instead.
   flags:
     description: 'Additional reviewdog flags'
     default: ''

--- a/script.sh
+++ b/script.sh
@@ -99,6 +99,16 @@ echo '::endgroup::'
 echo '::group:: Running trivy with reviewdog 🐶 ...'
   export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
+  if [[ -n "${INPUT_FAIL_LEVEL}" ]]; then
+    fail_level="--fail-level=${INPUT_FAIL_LEVEL}"
+  elif [[ "${INPUT_FAIL_ON_ERROR}" = "true" ]]; then
+    # For backward compatibility, default to any if fail-on-error is true
+    # Deprecated
+    fail_level="--fail-level=any"
+  else
+    fail_level=""
+  fi
+
   # Allow failures now, as reviewdog handles them
   set +Eeuo pipefail
 
@@ -108,7 +118,7 @@ echo '::group:: Running trivy with reviewdog 🐶 ...'
         -name="${INPUT_TOOL_NAME}" \
         -reporter="${INPUT_REPORTER}" \
         -level="${INPUT_LEVEL}" \
-        -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
+        ${fail_level} \
         -filter-mode="${INPUT_FILTER_MODE}" \
         ${INPUT_FLAGS}
 

--- a/script.sh
+++ b/script.sh
@@ -99,16 +99,6 @@ echo '::endgroup::'
 echo '::group:: Running trivy with reviewdog 🐶 ...'
   export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
-  if [[ -n "${INPUT_FAIL_LEVEL}" ]]; then
-    fail_level="--fail-level=${INPUT_FAIL_LEVEL}"
-  elif [[ "${INPUT_FAIL_ON_ERROR}" = "true" ]]; then
-    # For backward compatibility, default to any if fail-on-error is true
-    # Deprecated
-    fail_level="--fail-level=any"
-  else
-    fail_level=""
-  fi
-
   # Allow failures now, as reviewdog handles them
   set +Eeuo pipefail
 
@@ -118,7 +108,8 @@ echo '::group:: Running trivy with reviewdog 🐶 ...'
         -name="${INPUT_TOOL_NAME}" \
         -reporter="${INPUT_REPORTER}" \
         -level="${INPUT_LEVEL}" \
-        ${fail_level} \
+        -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
+        -fail-level="${INPUT_FAIL_LEVEL}" \
         -filter-mode="${INPUT_FILTER_MODE}" \
         ${INPUT_FLAGS}
 


### PR DESCRIPTION
Support reviewdog command line argument changes.

New: support fail-level
Deprecated: fail-on-error

See: https://github.com/reviewdog/action-trivy/issues/70
See also: https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md#rotating_light-deprecation-warnings