### PR TITLE
Add `enable_debug` flag for debugging

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,11 @@ inputs:
       Default is blank.
     default: ''
     required: false
+  enable_debug:
+    description: |
+      Enable debug mode (add -x option to shell script and -tee option to reviewdog)
+    default: false
+    required: false
 
 outputs:
   trivy-return-code:
@@ -99,7 +104,7 @@ runs:
         INPUT_TRIVY_COMMAND: ${{ inputs.trivy_command }}
         INPUT_TRIVY_TARGET: ${{ inputs.trivy_target }}
         INPUT_TRIVY_FLAGS: ${{ inputs.trivy_flags }}
-
+        INPUT_ENABLE_DEBUG: ${{ inputs.enable_debug }}
 branding:
   icon: 'edit'
   color: 'gray-dark'

--- a/script.sh
+++ b/script.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Print commands for debugging
-if [[ "$RUNNER_DEBUG" = "1" ]]; then
+if [[ "$RUNNER_DEBUG" = "1" || "$INPUT_ENABLE_DEBUG" = "true" ]]; then
   set -x
 fi
 
@@ -102,6 +102,10 @@ echo '::group:: Running trivy with reviewdog 🐶 ...'
   # Allow failures now, as reviewdog handles them
   set +Eeuo pipefail
 
+  if [[ "$INPUT_ENABLE_DEBUG" = "true" ]]; then
+    REVIEWDOG_ADDITIONAL_FLAGS="-tee"
+  fi
+
   # shellcheck disable=SC2086
   "${TRIVY_PATH}/trivy" --format sarif ${INPUT_TRIVY_FLAGS:-} --exit-code 1 ${INPUT_TRIVY_COMMAND} ${INPUT_TRIVY_TARGET} 2> /dev/null \
     |  "${REVIEWDOG_PATH}/reviewdog" -f=sarif \
@@ -110,6 +114,7 @@ echo '::group:: Running trivy with reviewdog 🐶 ...'
         -level="${INPUT_LEVEL}" \
         -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
         -filter-mode="${INPUT_FILTER_MODE}" \
+        ${REVIEWDOG_FLAGS} \
         ${INPUT_FLAGS}
 
   trivy_return="${PIPESTATUS[0]}" reviewdog_return="${PIPESTATUS[1]}" exit_code=$?


### PR DESCRIPTION
Purpose: Currently, we cannot enable debug output only with GitHub Actions' yml. Therefore, add the `enable_debug` flag.