### PR TITLE
fix: pass GITHUB_TOKEN to reviewdog install.sh to avoid rate limiting

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -51,7 +51,7 @@ echo '::group::Preparing ...'
 echo '::endgroup::'
 
 echo "::group::🐶 Installing reviewdog (${REVIEWDOG_VERSION}) ... https://github.com/reviewdog/reviewdog"
-  curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/fd59714416d6d9a1c0692d872e38e7f8448df4fc/install.sh | sh -s -- -b "${REVIEWDOG_PATH}" "${REVIEWDOG_VERSION}" 2>&1
+  curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/9b54cccfb4bf2509aef8a3e26899412348b62ce9/install.sh | GITHUB_TOKEN="${INPUT_GITHUB_TOKEN}" sh -s -- -b "${REVIEWDOG_PATH}" "${REVIEWDOG_VERSION}" 2>&1
 echo '::endgroup::'
 
 echo "::group:: Installing trivy (${INPUT_TRIVY_VERSION}) ... https://github.com/aquasecurity/trivy"


### PR DESCRIPTION
## Problem

The reviewdog install step intermittently fails with:

    unable to find 'v0.21.0' - use 'latest' or see https://github.com/reviewdog/reviewdog/releases for details

even though the version exists. This is caused by **unauthenticated rate limiting**.

## Root cause

`script.sh` pins the reviewdog `install.sh` to commit
`fd59714416d6d9a1c0692d872e38e7f8448df4fc` (2024-12-04). In that version,
`tag_to_version()` always calls `github_release()`, which fetches
`https://github.com/reviewdog/reviewdog/releases/<tag>` **without any auth
header**. On shared GitHub Actions runner IPs this gets rate-limited, the JSON
comes back empty, `REALTAG` is empty, and install aborts with "unable to find".

reviewdog added `GITHUB_TOKEN` support to `install.sh` on 2025-08-21
(migration from godownloader to binstaller, "adds GitHub token support for
better rate limiting handling"), but the pinned SHA here was never bumped — so
the token-aware code path is never used.

## Fix

- Bump the pinned `install.sh` to `9b54cccfb4bf2509aef8a3e26899412348b62ce9`
  (token-aware, binstaller-generated).
- Pass `GITHUB_TOKEN` (from the existing `github_token` input via
  `INPUT_GITHUB_TOKEN`) to the install script so the tag-resolution and
  download requests are authenticated.

The `github_token` input already exists and defaults to `${{ github.token }}`,
so no new input or breaking change is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)